### PR TITLE
ノートID入力画面の入力自動修正機能まわりの改善

### DIFF
--- a/src/components/GetNote.svelte
+++ b/src/components/GetNote.svelte
@@ -4,14 +4,31 @@
   import { getNote, splitEmojis } from "../lib/misskey";
 
   let noteId = "";
+  
+  let sanitizedNoteId = "";
+  let sanitizedServerUrl = "";
+
+  $: {
+    sanitizedNoteId = noteId
+      .replace(/.*\//, "");
+  }
+
+  $: {
+    const sanitizedServerUrlTail = $serverUrl
+      .replace(/^\w*:\/\//, "")
+      .replace(/\/$/, "");
+
+    sanitizedServerUrl = [
+      sanitizedServerUrlTail.startsWith("localhost:") ? "http://" : "https://",
+      sanitizedServerUrlTail,
+    ].join("");
+  }
 
   let noteResponse = "";
 
   const getNoteData = async () => {
-    noteId = noteId
-      .replace("https://", "")
-      .replace(get(serverUrl), "")
-      .replace("/notes/", "");
+    noteId = sanitizedNoteId;
+    serverUrl.set(sanitizedServerUrl);
 
     const noteData = await getNote(noteId);
     note.set(noteData);
@@ -29,9 +46,20 @@
       bind:value={$serverUrl}
       type="text"
       class="input input-xs md:input-md input-bordered md:w-64"
-      placeholder="EX:voskey.icalo.net"
+      placeholder="EX: https://voskey.icalo.net"
       oninput={updateCookie}
     />
+    {#if $serverUrl !== sanitizedServerUrl}
+      <div class="text-sm mt-1">
+        {sanitizedServerUrl} に自動修正されます 
+        <button
+          class="btn btn-xs inline-block"
+          onclick={() => serverUrl.set(sanitizedServerUrl)}
+        >
+        今すぐ修正
+        </button>
+      </div>
+    {/if}
   </div>
   <div>
     <label for="access-token">アクセストークン</label>
@@ -44,22 +72,34 @@
     />
   </div>
   <div>
-    <label for="server-url">ノートID</label>
+    <label for="note-id">ノートID</label>
     <input
       id="note-id"
       bind:value={noteId}
       type="text"
       class="input input-xs md:input-md input-bordered md:w-64"
+      oninput={updateCookie}
     />
+    {#if noteId !== sanitizedNoteId}
+      <div class="text-sm mt-1">
+        {sanitizedNoteId} に自動修正されます 
+        <button
+          class="btn btn-xs inline-block"
+          onclick={() => noteId = sanitizedNoteId}
+        >
+        今すぐ修正
+        </button>
+      </div>
+    {/if}
   </div>
   <div>
-    <label for="server-url">デフォルトffmpeg引数</label>
+    <label for="default-ffmpeg-args">デフォルトffmpeg引数</label>
     <input
       id="default-ffmpeg-args"
       bind:value={$defaultFFMpegArgs}
       type="text"
       class="input input-xs md:input-md input-bordered md:w-64"
-      placeholder="EX:voskey.icalo.net"
+      placeholder="EX: -lossless 1"
       oninput={updateCookie}
     />
   </div>

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -84,7 +84,7 @@ export const addEmoji = async (request: AdminEmojiAddRequest, file: File) => {
   const formData = new FormData();
   formData.append("i", get(accessToken));
   formData.append("file", file);
-  const createFile = await (await miApi.fetch(`https://${get(serverUrl)}/api/drive/files/create`, {
+  const createFile = await (await miApi.fetch(`${get(serverUrl)}/api/drive/files/create`, {
     method: "POST", body: formData })).json() as any as DriveFilesCreateResponse
   request.fileId = createFile.id;
   await miApi.request("admin/emoji/add", request);

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -21,7 +21,7 @@ const TAGSPLITCHAR = " "
 
 export const init = () => {
   miApi = new api.APIClient({
-    origin: "https://" + get(serverUrl),
+    origin: get(serverUrl),
     credential: get(accessToken),
   })
 }


### PR DESCRIPTION
はじめまして、FineArchsです。（ぼすきーではヒマントトプフと名乗っています）

ノートID入力画面において、
- 今まで「ノートID」欄にURLが入力された場合は暗黙にIDに変換されていましたが、「○○に修正されます」という注意書きが出るようにします。
- 「今すぐ修正」ボタンでその場で修正できるようにします。
- URL → IDの変換方法を簡潔化します。（`/`以前を全部除去）
- 「サーバーURL」欄にも類似の機能を追加します。
- 「サーバーURL」欄の入力には`https://`も必要になるようにします。（楽な入力方法がURLコピペなので）
  - 無いと自動修正で付けられます。
  - `localhost`の場合は`http://`になります。
- その他少し修正があります。

[参考画像](https://github.com/user-attachments/assets/f9000b66-169c-4da7-bf47-c2f32139017c)